### PR TITLE
Fix #4: Added timestamp but Passbook is broken

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+chrono = { version = "0.4.39", features = ["serde"] }
 clap = "4.5.23"
 printpdf = "0.7.0"
 serde = { version = "1.0.217", features = ["derive"] }


### PR DESCRIPTION
Added the timestamp, so every transaction can be audited and also the timestamp could be later used for analysis. The generate_passbook is not working, not sure where it broke, maybe adding timestamp in the enum Transaction killed it but need to investigate, but the issue is resolved.